### PR TITLE
fix: remove type

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   ],
   "author": "benoit ranque",
   "license": "MIT",
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/benoitranque/hasura-metadata-merge.git"


### PR DESCRIPTION
The issue with `type` in package.json


Code:
```
import { mergeMetadataDirectories } from 'hasura-metadata-merge';
```

Execution:
`REPOS_TO_MERGE='test, test1' npx ts-node index.ts`

Stack trace:
```
Must use import to load ES Module: au-hasura-metadata/node_modules/hasura-metadata-merge/dist/index.js
require() of ES modules is not supported.
require() of au-hasura-metadata/node_modules/hasura-metadata-merge/dist/index.js from au-hasura-metadata/index.ts is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from au-hasura-metadata/node_modules/hasura-metadata-merge/package.json.
```